### PR TITLE
Adding some settings for Debuginfod symbol locator

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolLocator.h
+++ b/lldb/include/lldb/Symbol/SymbolLocator.h
@@ -24,6 +24,11 @@ public:
   /// found, this will notify all target which contain the module with the
   /// given UUID.
   static void DownloadSymbolFileAsync(const UUID &uuid);
+  /// Normally, DownloadSymbolFileAsync will only try to download a given
+  /// UUID once. If the configuration for locating symbols has been changed
+  /// by the user, this function will reset that counter so that we will
+  /// attempt to download again.
+  static void ResetDownloadAttempts();
 };
 
 } // namespace lldb_private

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -47,6 +47,31 @@ LLDB_BASE_DIR := $(THIS_FILE_DIR)/../../../../../
 .DEFAULT_GOAL := all
 
 #----------------------------------------------------------------------
+# If OS is not defined, use 'uname -s' to determine the OS name.
+#
+# GNUWin32 uname gives "windows32" or "server version windows32" while
+# some versions of MSYS uname return "MSYS_NT*", but most environments
+# standardize on "Windows_NT", so we'll make it consistent here.
+# When running tests from Visual Studio, the environment variable isn't
+# inherited all the way down to the process spawned for make.
+#----------------------------------------------------------------------
+ifeq "$(HOST_OS)" ""
+  HOST_OS := $(shell uname -s)
+endif
+
+ifneq (,$(findstring windows32,$(HOST_OS)))
+	HOST_OS := Windows_NT
+endif
+
+ifneq (,$(findstring MSYS_NT,$(HOST_OS)))
+	HOST_OS := Windows_NT
+endif
+
+ifeq "$(OS)" ""
+	OS := $(HOST_OS)
+endif
+
+#----------------------------------------------------------------------
 # If OS is Windows, force SHELL to be cmd
 #
 # Some versions of make on Windows will search for other shells such as
@@ -595,7 +620,6 @@ ifeq "$(MAKE_DWP)" "YES"
 	$(DWP) -o "$(DWP_NAME)" $(DWOS)
 endif
 endif
-
 
 #----------------------------------------------------------------------
 # Make the dylib

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.h
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.h
@@ -47,6 +47,14 @@ public:
   static std::optional<FileSpec>
   LocateExecutableSymbolFile(const ModuleSpec &module_spec,
                              const FileSpecList &default_search_paths);
+
+  // Download the object and symbol files given a module specification.
+  //
+  // This will be done asynchronously, and is controlled by the
+  // plugin.symbol-locator.debuginfod.lookup_mode setting.
+  static bool DownloadObjectAndSymbolFile(ModuleSpec &module_spec,
+                                          Status &error, bool sync_lookup,
+                                          bool copy_executable);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfodProperties.td
@@ -7,6 +7,10 @@ let Definition = "symbollocatordebuginfod" in {
   def SymbolCachePath: Property<"cache-path", "String">,
     DefaultStringValue<"">,
     Desc<"The path where symbol files should be cached. This defaults to LLDB's system cache location.">;
+  def EnableAutoLookup : Property<"lookup-mode", "Enum">,
+    DefaultEnumValue<"eLookupModeOnDemand">,
+    EnumValues<"OptionEnumValues(g_debuginfod_symbol_lookup_mode)">,
+    Desc<"Control when DEBUGINFOD servers are queried for symbols">;
   def Timeout : Property<"timeout", "UInt64">,
     DefaultUnsignedValue<0>,
     Desc<"Timeout (in seconds) for requests made to a DEBUGINFOD server. A value of zero means we use the debuginfod default timeout: DEBUGINFOD_TIMEOUT if the environment variable is set and 90 seconds otherwise.">;

--- a/lldb/source/Symbol/SymbolLocator.cpp
+++ b/lldb/source/Symbol/SymbolLocator.cpp
@@ -18,9 +18,14 @@
 using namespace lldb;
 using namespace lldb_private;
 
+namespace {
+
+llvm::SmallSet<UUID, 8> g_seen_uuids;
+static std::mutex g_mutex;
+
+} // namespace
+
 void SymbolLocator::DownloadSymbolFileAsync(const UUID &uuid) {
-  static llvm::SmallSet<UUID, 8> g_seen_uuids;
-  static std::mutex g_mutex;
 
   auto lookup = [=]() {
     {
@@ -54,4 +59,9 @@ void SymbolLocator::DownloadSymbolFileAsync(const UUID &uuid) {
     lookup();
     break;
   };
+}
+
+void SymbolLocator::ResetDownloadAttempts() {
+  std::lock_guard<std::mutex> guard(g_mutex);
+  g_seen_uuids.clear();
 }

--- a/llvm/include/llvm/Debuginfod/Debuginfod.h
+++ b/llvm/include/llvm/Debuginfod/Debuginfod.h
@@ -85,6 +85,10 @@ std::string getDebuginfodDebuginfoUrlPath(object::BuildIDRef ID);
 /// server URLs.
 Expected<std::string> getCachedOrDownloadDebuginfo(object::BuildIDRef ID);
 
+/// Fetches any debuginfod artifact from the specified cache directory and key.
+Expected<std::string> getCachedArtifact(StringRef UniqueKey,
+                                        StringRef CacheDirectoryPath);
+
 /// Fetches any debuginfod artifact using the default local cache directory and
 /// server URLs.
 Expected<std::string> getCachedOrDownloadArtifact(StringRef UniqueKey,

--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -248,27 +248,54 @@ static SmallVector<std::string, 0> getHeaders() {
   return Headers;
 }
 
-Expected<std::string> getCachedOrDownloadArtifact(
-    StringRef UniqueKey, StringRef UrlPath, StringRef CacheDirectoryPath,
-    ArrayRef<StringRef> DebuginfodUrls, std::chrono::milliseconds Timeout) {
+static SmallString<64> getCachedArtifactPath(StringRef UniqueKey,
+                                             StringRef CacheDirectoryPath) {
   SmallString<64> AbsCachedArtifactPath;
   sys::path::append(AbsCachedArtifactPath, CacheDirectoryPath,
                     "llvmcache-" + UniqueKey);
+  return AbsCachedArtifactPath;
+}
+
+static Expected<AddStreamFn>
+getCachedArtifactHelper(StringRef UniqueKey, StringRef CacheDirectoryPath,
+                        unsigned &Task) {
+  SmallString<64> AbsCachedArtifactPath =
+      getCachedArtifactPath(UniqueKey, CacheDirectoryPath);
 
   Expected<FileCache> CacheOrErr =
       localCache("Debuginfod-client", ".debuginfod-client", CacheDirectoryPath);
   if (!CacheOrErr)
     return CacheOrErr.takeError();
+  return (*CacheOrErr)(Task, UniqueKey, "");
+}
 
-  FileCache Cache = *CacheOrErr;
+Expected<std::string> getCachedArtifact(StringRef UniqueKey,
+                                        StringRef CacheDirectoryPath) {
   // We choose an arbitrary Task parameter as we do not make use of it.
   unsigned Task = 0;
-  Expected<AddStreamFn> CacheAddStreamOrErr = Cache(Task, UniqueKey, "");
+  Expected<AddStreamFn> CacheAddStreamOrErr =
+      getCachedArtifactHelper(UniqueKey, CacheDirectoryPath, Task);
+  if (!CacheAddStreamOrErr)
+    return CacheAddStreamOrErr.takeError();
+  if (!*CacheAddStreamOrErr)
+    return std::string(getCachedArtifactPath(UniqueKey, CacheDirectoryPath));
+  return createStringError(errc::argument_out_of_domain,
+                           "build id not found in cache");
+}
+
+Expected<std::string> getCachedOrDownloadArtifact(
+    StringRef UniqueKey, StringRef UrlPath, StringRef CacheDirectoryPath,
+    ArrayRef<StringRef> DebuginfodUrls, std::chrono::milliseconds Timeout) {
+  // We choose an arbitrary Task parameter as we do not make use of it.
+  unsigned Task = 0;
+  Expected<AddStreamFn> CacheAddStreamOrErr =
+      getCachedArtifactHelper(UniqueKey, CacheDirectoryPath, Task);
   if (!CacheAddStreamOrErr)
     return CacheAddStreamOrErr.takeError();
   AddStreamFn &CacheAddStream = *CacheAddStreamOrErr;
   if (!CacheAddStream)
-    return std::string(AbsCachedArtifactPath);
+    return std::string(getCachedArtifactPath(UniqueKey, CacheDirectoryPath));
+
   // The artifact was not found in the local cache, query the debuginfod
   // servers.
   if (!HTTPClient::isAvailable())
@@ -311,7 +338,7 @@ Expected<std::string> getCachedOrDownloadArtifact(
     pruneCache(CacheDirectoryPath, *PruningPolicyOrErr);
 
     // Return the path to the artifact on disk.
-    return std::string(AbsCachedArtifactPath);
+    return std::string(getCachedArtifactPath(UniqueKey, CacheDirectoryPath));
   }
 
   return createStringError(errc::argument_out_of_domain, "build id not found");


### PR DESCRIPTION
Adding configuration settings for Debuginfod symbol & binary acquisition:
```
plugin.symbol-locator.debuginfod.lookup-mode (enum) = on-demand
plugin.symbol-locator.debuginfod.server-urls (array of strings) =
plugin.symbol-locator.debuginfod.cache-path (string) =
plugin.symbol-locator.debuginfod.timeout (unsigned) = 0
```

As described, `lookup-mode on-demand` will only poll servers when the user has explicitly asked for them, or (if enabled using the existing `symbols.enable-background-lookup` setting) in the background after they're needed. `disabled` is obvious, and `always` synchronously polls servers.

The `cache-path` defaults to the Debuginfod cache path (on my system, the is `.cache/llvm-debuginfod/client`) and the `timeout` defaults to either DEBUGINFOD_TIMEOUT or 90 seconds (as configured in the Debuginfod library)

The background lookup code already only tries once, but with my change if you update the the `server-urls` setting, it will reset all teh "already looked up" flags.