### PR TITLE
Initial 'design' for aggregating verification errors in llvm-dwarfdump

### DIFF
--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -205,6 +205,7 @@ struct DIDumpOptions {
   bool DisplayRawContents = false;
   bool IsEH = false;
   bool DumpNonSkeleton = false;
+  bool DumpAggregateErrors = true;
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -205,7 +205,6 @@ struct DIDumpOptions {
   bool DisplayRawContents = false;
   bool IsEH = false;
   bool DumpNonSkeleton = false;
-  bool DumpAggregateErrors = true;
   std::function<llvm::StringRef(uint64_t DwarfRegNum, bool IsEH)>
       GetNameForDWARFReg;
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -32,16 +32,15 @@ struct DWARFSection;
 
 class OutputCategoryAggregator {
 private:
-  std::map<std::string, int> Aggregator;
-  bool Output;
+  std::map<std::string, unsigned> Aggregation;
+  bool CallDetail;
 
 public:
-  OutputCategoryAggregator(bool DetailedOutput = false)
-      : Output(DetailedOutput) {}
-  void EnableDetail() { Output = true; }
-  void DisableDetail() { Output = false; }
+  OutputCategoryAggregator(bool callDetail = false) : CallDetail(callDetail) {}
+  void EnableDetail() { CallDetail = true; }
+  void DisableDetail() { CallDetail = false; }
   void Report(StringRef s, std::function<void()> detailCallback);
-  void DumpAggregation(raw_ostream *o);
+  void HandleAggregate(std::function<void(StringRef, unsigned)> handleCounts);
 };
 
 /// A class that verifies DWARF debug information given a DWARF Context.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -101,8 +101,14 @@ private:
   bool IsMachOObject;
   using ReferenceMap = std::map<uint64_t, std::set<uint64_t>>;
 
-  raw_ostream &aggregate(const char *);
+  // For errors that have sensible names as the first (or only) string
+  // you can just use aggregate() << "DIE looks stupid: " << details...
+  // and it will get aggregated as "DIE looks stupid".
   ErrorAggregator &aggregate();
+  // For errors that have details before good 'categories', you'll need
+  // to provide the aggregated name, like this:
+  // aggregate("CU index is busted") << "CU index [" << n << "] is busted"
+  raw_ostream &aggregate(const char *);
   raw_ostream &error() const;
   raw_ostream &warn() const;
   raw_ostream &note() const;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -363,7 +363,7 @@ public:
       void (DWARFObject::*)(function_ref<void(const DWARFSection &)>) const);
 
   /// Emits any aggregate information collection, depending on the dump options
-  void finish();
+  void finish(bool Success);
 };
 
 static inline bool operator<(const DWARFVerifier::DieRangeInfo &LHS,

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -1408,7 +1408,7 @@ bool DWARFContext::verify(raw_ostream &OS, DIDumpOptions DumpOpts) {
   if (DumpOpts.DumpType & DIDT_DebugStrOffsets)
     Success &= verifier.handleDebugStrOffsets();
   Success &= verifier.handleAccelTables();
-  verifier.finish();
+  verifier.finish(Success);
   return Success;
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -1408,6 +1408,7 @@ bool DWARFContext::verify(raw_ostream &OS, DIDumpOptions DumpOpts) {
   if (DumpOpts.DumpType & DIDT_DebugStrOffsets)
     Success &= verifier.handleDebugStrOffsets();
   Success &= verifier.handleAccelTables();
+  verifier.finish();
   return Success;
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1997,11 +1997,14 @@ void OutputCategoryAggregator::HandleAggregate(
   }
 }
 
-void DWARFVerifier::finish() {
-  if (DumpOpts.DumpAggregateErrors)
+void DWARFVerifier::finish(bool Success) {
+  if (!Success) {
+    error() << "Aggregated error category counts:\n";
     ErrorCategory.HandleAggregate([&](StringRef s, unsigned count) {
-      error() << s << ": " << count << '\n';
+      error() << "Error category '" << s << "' occurred " << count
+              << " time(s).\n";
     });
+  }
 }
 
 raw_ostream &DWARFVerifier::error() const { return WithColor::error(OS); }

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -326,7 +326,7 @@ static DIDumpOptions getDumpOpts(DWARFContext &C) {
   DumpOpts.RecoverableErrorHandler = C.getRecoverableErrorHandler();
   // In -verify mode, print DIEs without children in error messages.
   if (Verify) {
-    DumpOpts.Verbose = true;
+    // DumpOpts.Verbose = true;
     return DumpOpts.noImplicitRecursion();
   }
   return DumpOpts;

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -276,6 +276,10 @@ static cl::opt<bool>
                 cat(DwarfDumpCategory));
 static opt<bool> Verify("verify", desc("Verify the DWARF debug info."),
                         cat(DwarfDumpCategory));
+static opt<bool> OnlyAggregateErrors(
+    "only-aggregate-errors",
+    desc("Only display the aggregate errors when verifying."),
+    cat(DwarfDumpCategory));
 static opt<bool> Quiet("quiet", desc("Use with -verify to not emit to STDOUT."),
                        cat(DwarfDumpCategory));
 static opt<bool> DumpUUID("uuid", desc("Show the UUID for each architecture."),
@@ -326,7 +330,7 @@ static DIDumpOptions getDumpOpts(DWARFContext &C) {
   DumpOpts.RecoverableErrorHandler = C.getRecoverableErrorHandler();
   // In -verify mode, print DIEs without children in error messages.
   if (Verify) {
-    // DumpOpts.Verbose = true;
+    DumpOpts.Verbose = !OnlyAggregateErrors;
     return DumpOpts.noImplicitRecursion();
   }
   return DumpOpts;


### PR DESCRIPTION
I'm not done (the final report is hideous, and I haven't gone through every error just yet) but I wanted to get any feedback on this particular design for how to aggregate errors in the verification pass.